### PR TITLE
unnecessary accepts qvalue when unique media-range

### DIFF
--- a/examples/tig.rb
+++ b/examples/tig.rb
@@ -2337,7 +2337,7 @@ class TwitterIrcGateway < Net::IRC::Server::Session
 	end
 
 	def http_req(method, uri, header = {}, credentials = nil)
-		accepts = ["*/*;q=0.1"]
+		accepts = ["*/*"]
 		#require "mime/types"; accepts.unshift MIME::Types.of(uri.path).first.simplified
 		types   = { "json" => "application/json", "txt" => "text/plain" }
 		ext     = uri.path[/[^.]+\z/]


### PR DESCRIPTION
HTTP_ACCEPT ヘッダが単一の場合は quality の指定は不要と思います。
