### PR TITLE
スレタイ候補走査で止まるの修正

### DIFF
--- a/examples/2ch.rb
+++ b/examples/2ch.rb
@@ -148,7 +148,7 @@ class ThreadData
 
 			uri = "http://#{@uri.host}/test/read.cgi/#{@board}/#{dat}/"
 
-			subject, n = */(.+?) \((\d+)\)/.match(rest).captures
+			subject, n = */(.*?) \((\d+)\)/.match(rest).captures
 			canonical_subject = canonicalize_subject(subject)
 			thread_rev     = canonical_subject[/\d+/].to_i
 


### PR DESCRIPTION
スレタイが特殊文字や空だった場合に .captures で止まるので正規表現修正しました。
